### PR TITLE
avoid twice urlencoding

### DIFF
--- a/Service/OAuthAbstractServerService.php
+++ b/Service/OAuthAbstractServerService.php
@@ -363,7 +363,7 @@ abstract class OAuthAbstractServerService implements OAuthServerServiceInterface
         $secretToken = (null !== $token) ? $token->getSecret() : '';
         $calculatedSignature = $signatureService->sign($baseString, $consumer->getConsumerSecret(), $secretToken);
 
-        return ($calculatedSignature === $signatureService->urlencode($requestParameters['oauth_signature']));
+        return ($calculatedSignature === $requestParameters['oauth_signature']);
     }
 
     /**


### PR DESCRIPTION
no need to encode a signature that has already been urlencoded
