### PR TITLE
Only fetching Authorization header from Apache and url decode $value.

### DIFF
--- a/Service/Signature/OAuthHmacSha1Signature.php
+++ b/Service/Signature/OAuthHmacSha1Signature.php
@@ -22,7 +22,7 @@ class OAuthHmacSha1Signature extends OAuthAbstractSignature
             $signature = $this->hashHmacSha1($baseString, $key);
         }
 
-        return $this->urlencode(base64_encode($signature));
+        return base64_encode($signature);
     }
 
     /**

--- a/Service/Signature/OAuthPlainTextSignature.php
+++ b/Service/Signature/OAuthPlainTextSignature.php
@@ -14,7 +14,7 @@ class OAuthPlainTextSignature extends OAuthAbstractSignature
      */
     public function sign($baseString, $consumerSecret, $tokenSecret = '')
     {
-        return $this->urlencode($consumerSecret) . $this->urlencode('&') . $this->urlencode($tokenSecret);
+        return base64_encode($this->urlencode($consumerSecret) . '&' . $this->urlencode($tokenSecret));
     }
 
     /**

--- a/Tests/Service/Signature/OAuthHmacSha1SignatureTest.php
+++ b/Tests/Service/Signature/OAuthHmacSha1SignatureTest.php
@@ -30,14 +30,14 @@ class OAuthHmacSha1SignatureTest extends TestCase
 
         $tokenSecret    = NULL;
         $this->assertEquals(
-            'egQqG5AJep5sJ7anhXju1unge2I%3D',
+            'egQqG5AJep5sJ7anhXju1unge2I=',
             $this->method->sign($baseString, $consumerSecret, $tokenSecret),
             'token secret is null'
         );
 
         $tokenSecret    = 'ts';
         $this->assertEquals(
-            'VZVjXceV7JgPq%2FdOTnNmEfO0Fv8%3D',
+            'VZVjXceV7JgPq/dOTnNmEfO0Fv8=',
             $this->method->sign($baseString, $consumerSecret, $tokenSecret),
             'token secret is not null'
         );

--- a/Tests/Service/Signature/OAuthPlainTextSignatureTest.php
+++ b/Tests/Service/Signature/OAuthPlainTextSignatureTest.php
@@ -29,22 +29,22 @@ class OAuthSignatureMethodPlaintextTest extends TestCase
         $consumerSecret = 'cs';
 
         $tokenSecret    = NULL;
-        $this->assertEquals('cs%26', $this->method->sign($baseString, $consumerSecret, $tokenSecret));
+        $this->assertEquals(base64_encode('cs&'), $this->method->sign($baseString, $consumerSecret, $tokenSecret));
 
         $tokenSecret    = 'ts';
-        $this->assertEquals('cs%26ts', $this->method->sign($baseString, $consumerSecret, $tokenSecret));
+        $this->assertEquals(base64_encode('cs&ts'), $this->method->sign($baseString, $consumerSecret, $tokenSecret));
 
         $consumerSecret = 'kd94hf93k423kf44';
         $tokenSecret    = 'pfkkdhi9sl3r4s00';
-        $this->assertEquals('kd94hf93k423kf44%26pfkkdhi9sl3r4s00', $this->method->sign($baseString, $consumerSecret, $tokenSecret));
+        $this->assertEquals(base64_encode('kd94hf93k423kf44&pfkkdhi9sl3r4s00'), $this->method->sign($baseString, $consumerSecret, $tokenSecret));
 
         // Tests taken from Chapter 9.4.1 ("Generating Signature") from the spec
         $consumerSecret = 'djr9rjt0jd78jf88';
         $tokenSecret    = 'jjd999tj88uiths3';
-        $this->assertEquals('djr9rjt0jd78jf88%26jjd999tj88uiths3', $this->method->sign($baseString, $consumerSecret, $tokenSecret));
+        $this->assertEquals(base64_encode('djr9rjt0jd78jf88&jjd999tj88uiths3'), $this->method->sign($baseString, $consumerSecret, $tokenSecret));
 
         $consumerSecret = 'djr9rjt0jd78jf88';
         $tokenSecret    = 'jjd99$tj88uiths3';
-        $this->assertEquals('djr9rjt0jd78jf88%26jjd99%24tj88uiths3', $this->method->sign($baseString, $consumerSecret, $tokenSecret));
+        $this->assertEquals(base64_encode('djr9rjt0jd78jf88&jjd99%24tj88uiths3'), $this->method->sign($baseString, $consumerSecret, $tokenSecret));
     }
 }


### PR DESCRIPTION
Because Symfony url decodes query and body values automatically, we have to do the same with the Authorization header values.

We only need the Authorization header in our functionality, so there is no need to set ALL headers back to the Request object.

When the all possible signatures are already url decoded, we do not have to url decode our generated signature. 
The PLAINTEXT method's ampersand does not has to be url encoded and the signature should be base64 as all method signatures should be. 

Works with Guzzle's OAuth plugin;
[link to code where Guzzle's signature key is generated](https://github.com/guzzle/guzzle/blob/master/src/Guzzle/Plugin/Oauth/OauthPlugin.php#L136)
[link to code where Guzzle's signature is base64 encoded, even if the method is PLAINTEXT](https://github.com/guzzle/guzzle/blob/master/src/Guzzle/Plugin/Oauth/OauthPlugin.php#L138)
