### PR TITLE
Same name for XAuth and OAuth server services

### DIFF
--- a/DependencyInjection/BazingaOAuthServerExtension.php
+++ b/DependencyInjection/BazingaOAuthServerExtension.php
@@ -35,24 +35,20 @@ class BazingaOAuthServerExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
-        $enableXAuth = isset($config['enable_xauth']) && true === $config['enable_xauth'];
-
-        if ($enableXAuth) {
-            $container->getDefinition('bazinga.oauth.controller.server')
-                ->replaceArgument(2, new Reference('bazinga.xauth.server_service'));
-            $container->getDefinition('bazinga.oauth.security.authentication.provider')
-                ->replaceArgument(1, new Reference('bazinga.xauth.server_service'));
+        $serverServiceClass = '%bazinga.oauth.server_service.oauth.class%';
+        if (isset($config['enable_xauth']) && true === $config['enable_xauth']) {
+            $serverServiceClass = '%bazinga.oauth.server_service.xauth.class%';
         }
+
+        $container->getDefinition('bazinga.oauth.server_service')->setClass($serverServiceClass);
 
         if (isset($config['service']) &&
             isset($config['service']['consumer_provider']) &&
             isset($config['service']['token_provider']) &&
             isset($config['service']['nonce_provider'])
         ) {
-            $serverServiceId = (true === $enableXAuth) ? 'bazinga.xauth.server_service' : 'bazinga.oauth.server_service';
-
             $container
-                ->getDefinition($serverServiceId)
+                ->getDefinition('bazinga.oauth.server_service')
                 ->replaceArgument(0, new Reference($config['service']['consumer_provider']))
                 ->replaceArgument(1, new Reference($config['service']['token_provider']))
                 ->replaceArgument(2, new Reference($config['service']['nonce_provider']));

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,9 +8,8 @@
         <parameter key="bazinga.oauth.controller.server.class">Bazinga\OAuthServerBundle\Controller\ServerController</parameter>
         <parameter key="bazinga.oauth.controller.login.class">Bazinga\OAuthServerBundle\Controller\LoginController</parameter>
 
-        <!-- OAuth server service -->
-        <parameter key="bazinga.oauth.server_service.class">Bazinga\OAuthServerBundle\Service\OAuthServerService</parameter>
-        <parameter key="bazinga.xauth.server_service.class">Bazinga\OAuthServerBundle\Service\XAuthServerService</parameter>
+        <parameter key="bazinga.oauth.server_service.oauth.class">Bazinga\OAuthServerBundle\Service\OAuthServerService</parameter>
+        <parameter key="bazinga.oauth.server_service.xauth.class">Bazinga\OAuthServerBundle\Service\XAuthServerService</parameter>
 
         <!-- Signatures -->
         <parameter key="bazinga.oauth.signature.plaintext.class">Bazinga\OAuthServerBundle\Service\Signature\OAuthPlainTextSignature</parameter>
@@ -40,13 +39,7 @@
         </service>
 
         <!-- OAuth server services -->
-        <service id="bazinga.oauth.server_service" class="%bazinga.oauth.server_service.class%">
-            <argument></argument> <!-- consumer provider -->
-            <argument></argument> <!-- token provider -->
-            <argument></argument> <!-- nonce provider -->
-            <argument type="service" id="logger" />
-        </service>
-        <service id="bazinga.xauth.server_service" class="%bazinga.xauth.server_service.class%">
+        <service id="bazinga.oauth.server_service">
             <argument></argument> <!-- consumer provider -->
             <argument></argument> <!-- token provider -->
             <argument></argument> <!-- nonce provider -->


### PR DESCRIPTION
I have given both the server services the same service definition and set the class according to if xauth is enabled or not. This way you do not have to know if xauth is enabled or not, you can just get the _bazinga.oauth.server_service_ service in your code. See it as some sort of alias.
This is in preparation for a cli command that cleans up expired tokens.
