### PR TITLE
Added provider classses and model mappings for all doctrine datastores

### DIFF
--- a/BazingaOAuthServerBundle.php
+++ b/BazingaOAuthServerBundle.php
@@ -2,12 +2,15 @@
 
 namespace Bazinga\OAuthServerBundle;
 
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-
 use Bazinga\OAuthServerBundle\DependencyInjection\BazingaOAuthServerExtension;
 use Bazinga\OAuthServerBundle\DependencyInjection\Compiler\AddSignaturesPass;
+use Bazinga\OAuthServerBundle\DependencyInjection\Compiler\RegisterMappingsPass;
 use Bazinga\OAuthServerBundle\DependencyInjection\Security\Factory\OAuthFactory;
+use Doctrine\Bundle\CouchDBBundle\DependencyInjection\Compiler\DoctrineCouchDBMappingsPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author William DURAND <william.durand1@gmail.com>
@@ -33,5 +36,26 @@ class BazingaOAuthServerBundle extends Bundle
 
         $extension = $container->getExtension('security');
         $extension->addSecurityListenerFactory(new OAuthFactory());
+
+        $this->addRegisterMappingsPass($container);
+    }
+
+    private function addRegisterMappingsPass(ContainerBuilder $container)
+    {
+        $mappings = array(
+            realpath(__DIR__ . '/Resources/config/model') => 'Bazinga\OAuthServerBundle\Model',
+        );
+
+        if (class_exists('Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass')) {
+            $container->addCompilerPass(DoctrineOrmMappingsPass::createXmlMappingDriver($mappings, array('bazinga.oauth.model_manager_name'), 'bazinga.oauth.backend_type_orm'));
+        }
+
+        if (class_exists('Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\DoctrineMongoDBMappingsPass')) {
+            $container->addCompilerPass(DoctrineMongoDBMappingsPass::createXmlMappingDriver($mappings, array('bazinga.oauth.model_manager_name'), 'bazinga.oauth.backend_type_mongodb'));
+        }
+
+        if (class_exists('Doctrine\Bundle\CouchDBBundle\DependencyInjection\Compiler\DoctrineCouchDBMappingsPass')) {
+            $container->addCompilerPass(DoctrineCouchDBMappingsPass::createXmlMappingDriver($mappings, array('bazinga.oauth.model_manager_name'), 'bazinga.oauth.backend_type_couchdb'));
+        }
     }
 }

--- a/DependencyInjection/BazingaOAuthServerExtension.php
+++ b/DependencyInjection/BazingaOAuthServerExtension.php
@@ -35,6 +35,14 @@ class BazingaOAuthServerExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
+        $loader->load(sprintf('%s.xml', $config['mapping']['db_driver']));
+        $container->setParameter('bazinga.oauth.backend_type_' . $config['mapping']['db_driver'], true);
+
+        $container->setParameter('bazinga.oauth.model.consumer.class', $config['mapping']['consumer_class']);
+        $container->setParameter('bazinga.oauth.model.request_token.class', $config['mapping']['request_token_class']);
+        $container->setParameter('bazinga.oauth.model.access_token.class', $config['mapping']['access_token_class']);
+        $container->setParameter('bazinga.oauth.model_manager_name', $config['mapping']['model_manager_name']);
+
         $serverServiceClass = '%bazinga.oauth.server_service.oauth.class%';
         if (isset($config['enable_xauth']) && true === $config['enable_xauth']) {
             $serverServiceClass = '%bazinga.oauth.server_service.xauth.class%';
@@ -43,13 +51,6 @@ class BazingaOAuthServerExtension extends Extension
         $container
             ->getDefinition('bazinga.oauth.server_service')
             ->setClass($serverServiceClass)
-            ->replaceArgument(0, new Reference($config['service']['consumer_provider']))
-            ->replaceArgument(1, new Reference($config['service']['token_provider']))
             ->replaceArgument(2, new Reference($config['service']['nonce_provider']));
-
-        $container->getDefinition('bazinga.oauth.controller.server')
-            ->replaceArgument(3, new Reference($config['service']['token_provider']));
-        $container->getDefinition('bazinga.oauth.controller.login')
-            ->replaceArgument(2, new Reference($config['service']['token_provider']));
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,7 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('bazinga_oauth_server');
 
         $this->addDefaultSection($rootNode);
+        $this->addMappingSection($rootNode);
         $this->addServiceSection($rootNode);
 
         return $treeBuilder;
@@ -35,6 +36,33 @@ class Configuration implements ConfigurationInterface
             ->end();
     }
 
+    private function addMappingSection(ArrayNodeDefinition $node)
+    {
+        $supportedDrivers = array('orm', 'mongodb', 'couchdb');
+
+        $node
+            ->children()
+                ->arrayNode('mapping')
+                    ->isRequired()
+                    ->children()
+                        ->scalarNode('db_driver')
+                            ->validate()
+                                ->ifNotInArray($supportedDrivers)
+                                ->thenInvalid('The driver %s is not supported. Please choose one of '.json_encode($supportedDrivers))
+                            ->end()
+                            ->cannotBeOverwritten()
+                            ->isRequired()
+                            ->cannotBeEmpty()
+                        ->end()
+                        ->scalarNode('consumer_class')->isRequired()->cannotBeEmpty()->end()
+                        ->scalarNode('request_token_class')->isRequired()->cannotBeEmpty()->end()
+                        ->scalarNode('access_token_class')->isRequired()->cannotBeEmpty()->end()
+                        ->scalarNode('model_manager_name')->defaultNull()->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
     private function addServiceSection(ArrayNodeDefinition $node)
     {
         $node
@@ -42,8 +70,6 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('service')
                     ->isRequired()
                     ->children()
-                        ->scalarNode('consumer_provider')->isRequired()->cannotBeEmpty()->end()
-                        ->scalarNode('token_provider')->isRequired()->cannotBeEmpty()->end()
                         ->scalarNode('nonce_provider')->isRequired()->cannotBeEmpty()->end()
                     ->end()
                 ->end()

--- a/Doctrine/Provider/ConsumerProvider.php
+++ b/Doctrine/Provider/ConsumerProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Bazinga\OAuthServerBundle\Doctrine\Provider;
+
+use Bazinga\OAuthServerBundle\Model\Provider\ConsumerProvider as BaseConsumerProvider;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectRepository;
+
+/**
+ * @author Robin van der Vleuten <robinvdvleuten@gmail.com>
+ */
+class ConsumerProvider extends BaseConsumerProvider
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * ObjectRepository
+     */
+    private $repository;
+
+    /**
+     * Constructor
+     *
+     * @param ObjectManager $objectManager A ObjectManager instance.
+     * @param string        $class
+     */
+    public function __construct(ObjectManager $objectManager, $class)
+    {
+        $this->objectManager = $objectManager;
+        $this->class = $class;
+
+        $this->repository = $objectManager->getRepository($class);
+    }
+
+    /**
+      * {@inheritDoc}
+      */
+    public function getClass()
+    {
+        return $this->class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConsumerBy(array $criteria)
+    {
+        return $this->repository->findOneBy($criteria);
+    }
+}

--- a/Doctrine/Provider/TokenProvider.php
+++ b/Doctrine/Provider/TokenProvider.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Bazinga\OAuthServerBundle\Doctrine\Provider;
+
+use Bazinga\OAuthServerBundle\Model\Provider\TokenProvider as BaseTokenProvider;
+use Bazinga\OAuthServerBundle\Model\TokenInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectRepository;
+
+/**
+ * @author Robin van der Vleuten <robinvdvleuten@gmail.com>
+ */
+class TokenProvider extends BaseTokenProvider
+{
+    /**
+     * @var string
+     */
+    private $requestTokenClass;
+
+    /**
+     * ObjectRepository
+     */
+    private $requestTokenRepository;
+
+    /**
+     * @var string
+     */
+    private $accessTokenClass;
+
+    /**
+     * ObjectRepository
+     */
+    private $accessTokenRepository;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * Constructor
+     *
+     * @param ObjectManager $objectManager A ObjectManager instance.
+     * @param string        $accessTokenClass
+     * @param string        $requestTokenClass
+     */
+    public function __construct(ObjectManager $objectManager, $requestTokenClass, $accessTokenClass)
+    {
+        $this->objectManager = $objectManager;
+        $this->requestTokenClass = $requestTokenClass;
+        $this->accessTokenClass = $accessTokenClass;
+
+        $this->requestTokenRepository = $objectManager->getRepository($requestTokenClass);
+        $this->accessTokenRepository = $objectManager->getRepository($accessTokenClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRequestTokenClass()
+    {
+        return $this->requestTokenClass;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAccessTokenClass()
+    {
+        return $this->accessTokenClass;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function loadRequestTokenBy(array $criteria)
+    {
+        return $this->requestTokenRepository->findOneBy($criteria);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function loadRequestTokens()
+    {
+        return $this->requestTokenRepository->findAll();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function loadAccessTokenBy(array $criteria)
+    {
+        return $this->accessTokenRepository->findOneBy($criteria);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function loadAccessTokens()
+    {
+        return $this->requestTokenRepository->findAll();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deleteToken(TokenInterface $token)
+    {
+        $this->objectManager->remove($token);
+        $this->objectManager->flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function updateToken(TokenInterface $token)
+    {
+        $this->objectManager->persist($token);
+        $this->objectManager->flush();
+    }
+}

--- a/Model/AccessToken.php
+++ b/Model/AccessToken.php
@@ -5,7 +5,7 @@ namespace Bazinga\OAuthServerBundle\Model;
 /**
  * @author Robin van der Vleuten <robinvdvleuten@gmail.com>
  */
-class AccessToken extends Token implements AccessTokenInterface
+abstract class AccessToken extends Token implements AccessTokenInterface
 {
 
 }

--- a/Model/Consumer.php
+++ b/Model/Consumer.php
@@ -5,8 +5,10 @@ namespace Bazinga\OAuthServerBundle\Model;
 /**
  * @author Robin van der Vleuten <robinvdvleuten@gmail.com>
  */
-class Consumer implements ConsumerInterface
+abstract class Consumer implements ConsumerInterface
 {
+    protected $id;
+
     /**
      * @var string
      */
@@ -30,9 +32,26 @@ class Consumer implements ConsumerInterface
     /**
      * {@inheritDoc}
      */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+        return $this;
     }
 
     /**
@@ -46,6 +65,15 @@ class Consumer implements ConsumerInterface
     /**
      * {@inheritDoc}
      */
+    public function setConsumerKey($consumerKey)
+    {
+        $this->consumerKey = $consumerKey;
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getConsumerSecret()
     {
         return $this->consumerSecret;
@@ -54,8 +82,26 @@ class Consumer implements ConsumerInterface
     /**
      * {@inheritDoc}
      */
+    public function setConsumerSecret($consumerSecret)
+    {
+        $this->consumerSecret = $consumerSecret;
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getCallback()
     {
         return $this->callback;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setCallback($callback)
+    {
+        $this->callback = $callback;
+        return $this;
     }
 }

--- a/Model/ConsumerInterface.php
+++ b/Model/ConsumerInterface.php
@@ -16,10 +16,24 @@ interface ConsumerInterface
     public function getName();
 
     /**
+     * Set name
+     * @param string $name
+     * @return self
+     */
+    public function setName($name);
+
+    /**
      * Returns the consumer key.
      * @return string The consumer key.
      */
     public function getConsumerKey();
+
+    /**
+     * Set consumerKey
+     * @param string $consumerKey
+     * @return self
+     */
+    public function setConsumerKey($consumerKey);
 
     /**
      * Returns the consumer secret.
@@ -28,8 +42,22 @@ interface ConsumerInterface
     public function getConsumerSecret();
 
     /**
+     * Set consumerSecret
+     * @param string $consumerSecret
+     * @return self
+     */
+    public function setConsumerSecret($consumerSecret);
+
+    /**
      * Returns the callback.
      * @return string The callback.
      */
     public function getCallback();
+
+    /**
+     * Set callback
+     * @param string $callback
+     * @return self
+     */
+    public function setCallback($callback);
 }

--- a/Model/Provider/ConsumerProvider.php
+++ b/Model/Provider/ConsumerProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bazinga\OAuthServerBundle\Model\Provider;
+
+/**
+ * @author Robin van der Vleuten <robinvdvleuten@gmail.com>
+ */
+abstract class ConsumerProvider implements ConsumerProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConsumerByKey($consumerKey)
+    {
+        return $this->getConsumerBy(array('consumerKey' => $consumerKey));
+    }
+}

--- a/Model/Provider/ConsumerProviderInterface.php
+++ b/Model/Provider/ConsumerProviderInterface.php
@@ -10,6 +10,19 @@ namespace Bazinga\OAuthServerBundle\Model\Provider;
 interface ConsumerProviderInterface
 {
     /**
+     * Returns the consumer's fully qualified class name.
+     *
+     * @return string
+     */
+    public function getClass();
+
+    /**
+     * @param array $criteria
+     * @return \Bazinga\OAuthServerBundle\Model\ConsumerInterface
+     */
+    public function getConsumerBy(array $criteria);
+
+    /**
      * @param $consumerKey
      * @return \Bazinga\OAuthServerBundle\Model\ConsumerInterface
      */

--- a/Model/Provider/TokenProvider.php
+++ b/Model/Provider/TokenProvider.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Bazinga\OAuthServerBundle\Model\Provider;
+
+use Bazinga\OAuthServerBundle\Model\AccessTokenInterface;
+use Bazinga\OAuthServerBundle\Model\ConsumerInterface;
+use Bazinga\OAuthServerBundle\Model\RequestTokenInterface;
+use Bazinga\OAuthServerBundle\Model\UserInterface;
+use Bazinga\OAuthServerBundle\Util\Random;
+
+/**
+ * @author Robin van der Vleuten <robinvdvleuten@gmail.com>
+ */
+abstract class TokenProvider implements TokenProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createRequestToken(ConsumerInterface $consumer)
+    {
+        $class = $this->getRequestTokenClass();
+
+        $requestToken = new $class;
+        $requestToken->setToken(Random::generateToken());
+        $requestToken->setSecret(Random::generateToken());
+        $requestToken->setExpiresAt(\DateTime::createFromFormat('U', time() + 3600));
+        $requestToken->setVerifier(Random::generateToken());
+        $requestToken->setConsumer($consumer);
+
+        $this->updateToken($requestToken);
+
+        return $requestToken;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function loadRequestTokenByToken($oauth_token)
+    {
+        return $this->loadRequestTokenBy(array('token' => $oauth_token));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUserForRequestToken(RequestTokenInterface $requestToken, UserInterface $user)
+    {
+        $requestToken->setUser($user);
+
+        $this->updateToken($requestToken);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deleteRequestToken(RequestTokenInterface $requestToken)
+    {
+        $this->deleteToken($requestToken);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createAccessToken(ConsumerInterface $consumer, UserInterface $user)
+    {
+        $class = $this->getAccessTokenClass();
+
+        $accessToken = new $class;
+        $accessToken->setToken(Random::generateToken());
+        $accessToken->setSecret(Random::generateToken());
+        $accessToken->setConsumer($consumer);
+        $accessToken->setUser($user);
+
+        $this->updateToken($accessToken);
+
+        return $accessToken;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function loadAccessTokenByToken($oauth_token)
+    {
+        return $this->loadAccessTokenBy(array('token' => $oauth_token));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deleteAccessToken(AccessTokenInterface $accessToken)
+    {
+        $this->deleteToken($accessToken);
+    }
+
+    /**
+     * @return int The number of tokens deleted.
+     */
+    public function deleteExpired()
+    {
+        $tokens = array_merge($this->loadRequestTokens(), $this->loadAccessTokens());
+
+        foreach ($tokens as $token) {
+            if ($token->hasExpired()) {
+                $this->deleteToken($token);
+            }
+        }
+    }
+}

--- a/Model/Provider/TokenProviderInterface.php
+++ b/Model/Provider/TokenProviderInterface.php
@@ -6,6 +6,7 @@ use Bazinga\OAuthServerBundle\Model\AccessTokenInterface;
 use Bazinga\OAuthServerBundle\Model\ConsumerInterface;
 use Bazinga\OAuthServerBundle\Model\RequestTokenInterface;
 use Bazinga\OAuthServerBundle\Model\UserInterface;
+use Bazinga\OAuthServerBundle\Model\TokenInterface;
 
 /**
  * OAuthTokenProviderInterface interface.
@@ -14,6 +15,20 @@ use Bazinga\OAuthServerBundle\Model\UserInterface;
  */
 interface TokenProviderInterface
 {
+    /**
+     * Returns the request token's fully qualified class name.
+     *
+     * @return string
+     */
+    public function getRequestTokenClass();
+
+    /**
+     * Returns the access token's fully qualified class name.
+     *
+     * @return string
+     */
+    public function getAccessTokenClass();
+
     /**
      * Create a request token.
      *
@@ -32,10 +47,27 @@ interface TokenProviderInterface
     public function createAccessToken(ConsumerInterface $consumer, UserInterface $user);
 
     /**
+     * @param array $criteria
+     * @return \Bazinga\OAuthServerBundle\Model\RequestTokenInterface
+     */
+    public function loadRequestTokenBy(array $criteria);
+
+    /**
      * @param $oauth_token
      * @return mixed
      */
     public function loadRequestTokenByToken($oauth_token);
+
+    /**
+     * @return \Traversable
+     */
+    public function loadRequestTokens();
+
+    /**
+     * @param array $criteria
+     * @return \Bazinga\OAuthServerBundle\Model\AccessTokenInterface
+     */
+    public function loadAccessTokenBy(array $criteria);
 
     /**
      * @param $oauth_token
@@ -44,11 +76,16 @@ interface TokenProviderInterface
     public function loadAccessTokenByToken($oauth_token);
 
     /**
+     * @return \Traversable
+     */
+    public function loadAccessTokens();
+
+    /**
      * @param  \Bazinga\OAuthServerBundle\Model\RequestTokenInterface $token
      * @param  \Bazinga\OAuthServerBundle\Model\UserInterface         $user
      * @return mixed
      */
-    public function setUserForRequestToken(RequestTokenInterface $token, UserInterface $user);
+    public function setUserForRequestToken(RequestTokenInterface $requestToken, UserInterface $user);
 
     /**
      * @param  \Bazinga\OAuthServerBundle\Model\RequestTokenInterface $requestToken
@@ -66,4 +103,20 @@ interface TokenProviderInterface
      * @return int The number of tokens deleted.
      */
     public function deleteExpired();
+
+    /**
+     * Deletes a token.
+     *
+     * @param TokenInterface $token
+     * @return void
+     */
+    public function deleteToken(TokenInterface $token);
+
+    /**
+     * Updates a token.
+     *
+     * @param TokenInterface $token
+     * @return void
+     */
+    public function updateToken(TokenInterface $token);
 }

--- a/Model/RequestToken.php
+++ b/Model/RequestToken.php
@@ -5,7 +5,7 @@ namespace Bazinga\OAuthServerBundle\Model;
 /**
  * @author Robin van der Vleuten <robinvdvleuten@gmail.com>
  */
-class RequestToken extends Token implements RequestTokenInterface
+abstract class RequestToken extends Token implements RequestTokenInterface
 {
     /**
      * @var string
@@ -18,5 +18,13 @@ class RequestToken extends Token implements RequestTokenInterface
     public function getVerifier()
     {
         return $this->verifier;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setVerifier($verifier)
+    {
+        $this->verifier = $verifier;
     }
 }

--- a/Model/RequestTokenInterface.php
+++ b/Model/RequestTokenInterface.php
@@ -14,4 +14,11 @@ interface RequestTokenInterface extends TokenInterface
      * @return string
      */
     public function getVerifier();
+
+    /**
+     * Sets the verifier string.
+     * @param string $verifier
+     * @return self
+     */
+    public function setVerifier($verifier);
 }

--- a/Model/Token.php
+++ b/Model/Token.php
@@ -5,8 +5,10 @@ namespace Bazinga\OAuthServerBundle\Model;
 /**
  * @author Robin van der Vleuten <robinvdvleuten@gmail.com>
  */
-class Token implements TokenInterface
+abstract class Token implements TokenInterface
 {
+    protected $id;
+
     /**
      * @var string
      */
@@ -18,12 +20,12 @@ class Token implements TokenInterface
     protected $secret;
 
     /**
-     * @var int
+     * @var \DateTime
      */
     protected $expiresAt;
 
     /**
-     * @var \Bazinga\OAuthServerBundle\Model\OAuthUserInterface
+     * @var UserInterface
      */
     protected $user;
 
@@ -35,9 +37,26 @@ class Token implements TokenInterface
     /**
      * {@inheritDoc}
      */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getToken()
     {
         return $this->token;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setToken($token)
+    {
+        $this->token = $token;
+        return $this;
     }
 
     /**
@@ -51,6 +70,15 @@ class Token implements TokenInterface
     /**
      * {@inheritDoc}
      */
+    public function setSecret($secret)
+    {
+        $this->secret = $secret;
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getExpiresAt()
     {
         return $this->expiresAt;
@@ -59,10 +87,19 @@ class Token implements TokenInterface
     /**
      * {@inheritDoc}
      */
+    public function setExpiresAt(\DateTime $expiresAt)
+    {
+        $this->expiresAt = $expiresAt;
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getExpiresIn()
     {
         if ($this->expiresAt) {
-            return $this->expiresAt - time();
+            return $this->expiresAt->getTimestamp() - time();
         }
 
         return PHP_INT_MAX;
@@ -74,7 +111,7 @@ class Token implements TokenInterface
     public function hasExpired()
     {
         if ($this->expiresAt) {
-            return time() > $this->expiresAt;
+            return time() > $this->expiresAt->getTimestamp();
         }
 
         return false;
@@ -86,6 +123,24 @@ class Token implements TokenInterface
     public function getUser()
     {
         return $this->user;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUser(UserInterface $user)
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setConsumer(ConsumerInterface $consumer)
+    {
+        $this->consumer = $consumer;
+        return $this;
     }
 
     /**

--- a/Model/TokenInterface.php
+++ b/Model/TokenInterface.php
@@ -16,16 +16,37 @@ interface TokenInterface
     public function getToken();
 
     /**
+     * Set token
+     * @param string $token
+     * @return self
+     */
+    public function setToken($token);
+
+    /**
      * Returns the secret string.
      * @return string
      */
     public function getSecret();
 
     /**
+     * Set secret
+     * @param string $secret
+     * @return self
+     */
+    public function setSecret($secret);
+
+    /**
      * Returns the expiration time.
      * @return int
      */
     public function getExpiresAt();
+
+    /**
+     * Set expiresAt
+     * @param \DateTime $expiresAt
+     * @return self
+     */
+    public function setExpiresAt(\DateTime $expiresAt);
 
     /**
      * Returns the expiration delay.
@@ -41,13 +62,26 @@ interface TokenInterface
 
     /**
      * Returns the user for this token.
-     * @return \Bazinga\OAuthServerBundle\Model\UserInterface
+     * @return UserInterface
      */
     public function getUser();
 
     /**
+     * Sets the user for this token.
+     * @return self
+     */
+    public function setUser(UserInterface $user);
+
+    /**
      * Returns the consumer for this token.
-     * @return \Bazinga\OAuthServerBundle\Model\ConsumerInterface
+     * @return ConsumerInterface
      */
     public function getConsumer();
+
+    /**
+     * Set consumer
+     * @param ConsumerInterface $consumer
+     * @return self
+     */
+    public function setConsumer(ConsumerInterface $consumer);
 }

--- a/Model/UserInterface.php
+++ b/Model/UserInterface.php
@@ -2,11 +2,13 @@
 
 namespace Bazinga\OAuthServerBundle\Model;
 
+use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
+
 /**
  * This interface represents a User.
  *
  * @author William DURAND <william.durand1@gmail.com>
  */
-interface UserInterface
+interface UserInterface extends BaseUserInterface
 {
 }

--- a/Resources/config/couchdb.xml
+++ b/Resources/config/couchdb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="bazinga.oauth.provider.consumer_provider.class">Bazinga\OAuthServerBundle\Doctrine\Provider\ConsumerProvider</parameter>
+        <parameter key="bazinga.oauth.provider.token_provider.class">Bazinga\OAuthServerBundle\Doctrine\Provider\TokenProvider</parameter>
+    </parameters>
+
+    <services>
+        <service id="bazinga.oauth.provider.consumer_provider" class="%bazinga.oauth.provider.consumer_provider.class%" public="false">
+            <argument type="service" id="bazinga.oauth.document_manager" />
+            <argument>%bazinga.oauth.model.consumer.class%</argument>
+        </service>
+
+        <service id="bazinga.oauth.provider.token_provider" class="%bazinga.oauth.provider.token_provider.class%" public="false">
+            <argument type="service" id="bazinga.oauth.document_manager" />
+            <argument>%bazinga.oauth.model.request_token.class%</argument>
+            <argument>%bazinga.oauth.model.access_token.class%</argument>
+        </service>
+
+        <service id="bazinga.oauth.document_manager" factory-service="doctrine_couchdb" factory-method="getManager" class="Doctrine\ODM\CouchDB\DocumentManager" public="false">
+            <argument>%bazinga.oauth.model_manager_name%</argument>
+        </service>
+    </services>
+</container>

--- a/Resources/config/model/AccessToken.couchdb.xml
+++ b/Resources/config/model/AccessToken.couchdb.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping>
+
+    <mapped-superclass name="Bazinga\OAuthServerBundle\Model\AccessToken">
+
+        <field name="token" fieldName="token" type="string" />
+
+        <field name="secret" fieldName="secret" type="string" />
+
+        <field name="expiresAt" fieldName="expiresAt" type="date" />
+
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/Resources/config/model/AccessToken.mongodb.xml
+++ b/Resources/config/model/AccessToken.mongodb.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <mapped-superclass name="Bazinga\OAuthServerBundle\Model\AccessToken">
+
+        <field name="token" fieldName="token" type="string" />
+
+        <field name="secret" fieldName="secret" type="string" />
+
+        <field name="expiresAt" fieldName="expiresAt" type="date" />
+
+    </mapped-superclass>
+
+</doctrine-mongo-mapping>

--- a/Resources/config/model/AccessToken.orm.xml
+++ b/Resources/config/model/AccessToken.orm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                  http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <mapped-superclass name="Bazinga\OAuthServerBundle\Model\AccessToken">
+
+        <field name="token" column="token" type="string" />
+
+        <field name="secret" column="secret" type="string" />
+
+        <field name="expiresAt" column="expiresAt" type="date" />
+
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/Resources/config/model/Consumer.couchdb.xml
+++ b/Resources/config/model/Consumer.couchdb.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping>
+
+    <mapped-superclass name="Bazinga\OAuthServerBundle\Model\Consumer">
+
+        <field name="name" fieldName="name" type="string" />
+
+        <field name="consumerKey" fieldName="consumerKey" type="string" />
+
+        <field name="consumerSecret" fieldName="consumerSecret" type="string" />
+
+        <field name="callback" fieldName="callback" type="string" />
+
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/Resources/config/model/Consumer.mongodb.xml
+++ b/Resources/config/model/Consumer.mongodb.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <mapped-superclass name="Bazinga\OAuthServerBundle\Model\Consumer">
+
+        <field name="name" fieldName="name" type="string" />
+
+        <field name="consumerKey" fieldName="consumerKey" type="string" />
+
+        <field name="consumerSecret" fieldName="consumerSecret" type="string" />
+
+        <field name="callback" fieldName="callback" type="string" />
+
+    </mapped-superclass>
+
+</doctrine-mongo-mapping>

--- a/Resources/config/model/Consumer.orm.xml
+++ b/Resources/config/model/Consumer.orm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                  http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <mapped-superclass name="Bazinga\OAuthServerBundle\Model\Consumer">
+
+        <field name="name" column="name" type="string" />
+
+        <field name="consumerKey" column="consumerKey" type="string" />
+
+        <field name="consumerSecret" column="consumerSecret" type="string" />
+
+        <field name="callback" column="callback" type="string" />
+
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/Resources/config/model/RequestToken.couchdb.xml
+++ b/Resources/config/model/RequestToken.couchdb.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping>
+
+    <mapped-superclass name="Bazinga\OAuthServerBundle\Model\RequestToken">
+
+        <field name="token" fieldName="token" type="string" />
+
+        <field name="secret" fieldName="secret" type="string" />
+
+        <field name="expiresAt" fieldName="expiresAt" type="date" />
+
+        <field name="verifier" fieldName="verifier" type="string" />
+
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/Resources/config/model/RequestToken.mongodb.xml
+++ b/Resources/config/model/RequestToken.mongodb.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <mapped-superclass name="Bazinga\OAuthServerBundle\Model\RequestToken">
+
+        <field name="token" fieldName="token" type="string" />
+
+        <field name="secret" fieldName="secret" type="string" />
+
+        <field name="expiresAt" fieldName="expiresAt" type="date" />
+
+        <field name="verifier" fieldName="verifier" type="string" />
+
+    </mapped-superclass>
+
+</doctrine-mongo-mapping>

--- a/Resources/config/model/RequestToken.orm.xml
+++ b/Resources/config/model/RequestToken.orm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                  http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <mapped-superclass name="Bazinga\OAuthServerBundle\Model\RequestToken">
+
+        <field name="token" column="token" type="string" />
+
+        <field name="secret" column="secret" type="string" />
+
+        <field name="expiresAt" column="expiresAt" type="date" />
+
+        <field name="verifier" column="verifier" type="string" />
+
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="bazinga.oauth.provider.consumer_provider.class">Bazinga\OAuthServerBundle\Doctrine\Provider\ConsumerProvider</parameter>
+        <parameter key="bazinga.oauth.provider.token_provider.class">Bazinga\OAuthServerBundle\Doctrine\Provider\TokenProvider</parameter>
+    </parameters>
+
+    <services>
+        <service id="bazinga.oauth.provider.consumer_provider" class="%bazinga.oauth.provider.consumer_provider.class%" public="false">
+            <argument type="service" id="bazinga.oauth.document_manager" />
+            <argument>%bazinga.oauth.model.consumer.class%</argument>
+        </service>
+
+        <service id="bazinga.oauth.provider.token_provider" class="%bazinga.oauth.provider.token_provider.class%" public="false">
+            <argument type="service" id="bazinga.oauth.document_manager" />
+            <argument>%bazinga.oauth.model.request_token.class%</argument>
+            <argument>%bazinga.oauth.model.access_token.class%</argument>
+        </service>
+
+        <service id="bazinga.oauth.document_manager" factory-service="doctrine_mongodb" factory-method="getManager" class="Doctrine\ODM\MongoDB\DocumentManager" public="false">
+            <argument>%bazinga.oauth.model_manager_name%</argument>
+        </service>
+    </services>
+</container>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="bazinga.oauth.provider.consumer_provider.class">Bazinga\OAuthServerBundle\Doctrine\Provider\ConsumerProvider</parameter>
+        <parameter key="bazinga.oauth.provider.token_provider.class">Bazinga\OAuthServerBundle\Doctrine\Provider\TokenProvider</parameter>
+    </parameters>
+
+    <services>
+        <service id="bazinga.oauth.provider.consumer_provider" class="%bazinga.oauth.provider.consumer_provider.class%" public="false">
+            <argument type="service" id="bazinga.oauth.entity_manager" />
+            <argument>%bazinga.oauth.model.consumer.class%</argument>
+        </service>
+
+        <service id="bazinga.oauth.provider.token_provider" class="%bazinga.oauth.provider.token_provider.class%" public="false">
+            <argument type="service" id="bazinga.oauth.entity_manager" />
+            <argument>%bazinga.oauth.model.request_token.class%</argument>
+            <argument>%bazinga.oauth.model.access_token.class%</argument>
+        </service>
+
+        <service id="bazinga.oauth.entity_manager" factory-service="doctrine" factory-method="getManager" class="Doctrine\ORM\EntityManager" public="false">
+            <argument>%bazinga.oauth.model_manager_name%</argument>
+        </service>
+    </services>
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -30,18 +30,18 @@
             <argument type="service" id="router" />
             <argument type="service" id="templating" />
             <argument type="service" id="bazinga.oauth.server_service" />
-            <argument></argument> <!-- token provider -->
+            <argument type="service" id="bazinga.oauth.provider.token_provider" />
         </service>
         <service id="bazinga.oauth.controller.login" class="%bazinga.oauth.controller.login.class%">
             <argument type="service" id="templating" />
             <argument type="service" id="security.context" />
-            <argument></argument> <!-- token provider -->
+            <argument type="service" id="bazinga.oauth.provider.token_provider" />
         </service>
 
         <!-- OAuth server services -->
         <service id="bazinga.oauth.server_service">
-            <argument></argument> <!-- consumer provider -->
-            <argument></argument> <!-- token provider -->
+            <argument type="service" id="bazinga.oauth.provider.consumer_provider" />
+            <argument type="service" id="bazinga.oauth.provider.token_provider" />
             <argument></argument> <!-- nonce provider -->
             <argument type="service" id="logger" />
         </service>

--- a/Resources/doc/README.markdown
+++ b/Resources/doc/README.markdown
@@ -38,8 +38,123 @@ bazinga_oauth:
     resource: "@BazingaOAuthServerBundle/Resources/config/routing/routing.yml"
 ```
 
-That's all for the installation :-)
+Create the required OAuth classes by extending all abstract model classes from the bundle:
 
+### Consumer class
+
+``` php
+<?php
+// src/Acme/OAuthBundle/Entity/Consumer.php
+
+namespace Acme\OAuthBundle\Entity;
+
+use Bazinga\OAuthServerBundle\Model\Consumer as BaseConsumer;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="consumers")
+ */
+class Consumer extends BaseConsumer
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+}
+```
+
+### Request Token class
+
+``` php
+<?php
+// src/Acme/OAuthBundle/Entity/RequestToken.php
+
+namespace Acme\OAuthBundle\Entity;
+
+use Bazinga\OAuthServerBundle\Model\RequestToken as BaseRequestToken;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="request_tokens")
+ */
+class RequestToken extends BaseRequestToken
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @ORM\OneToOne(targetEntity="Acme\OAuthBundle\Entity\Customer")
+     * @ORM\JoinColumn(name="customer_id", referencedColumnName="id")
+     */
+    protected $consumer;
+
+    /**
+     * @ORM\OneToOne(targetEntity="Acme\OAuthBundle\Entity\User")
+     * @ORM\JoinColumn(name="user_id", referencedColumnName="id")
+     */
+    protected $user;
+}
+```
+
+### Access Token class
+
+``` php
+<?php
+// src/Acme/OAuthBundle/Entity/AccessToken.php
+
+namespace Acme\OAuthBundle\Entity;
+
+use Bazinga\OAuthServerBundle\Model\AccessToken as BaseAccessToken;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="access_tokens")
+ */
+class AccessToken extends BaseAccessToken
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @ORM\OneToOne(targetEntity="Acme\OAuthBundle\Entity\Customer")
+     * @ORM\JoinColumn(name="customer_id", referencedColumnName="id")
+     */
+    protected $consumer;
+
+    /**
+     * @ORM\OneToOne(targetEntity="Acme\OAuthBundle\Entity\User")
+     * @ORM\JoinColumn(name="user_id", referencedColumnName="id")
+     */
+    protected $user;
+}
+```
+
+Enable the correct datastore driver in the bundle's configuration and set all corresponding OAuth classes:
+
+``` yaml
+# app/config/config.yml
+bazinga_oauth:
+    mapping:
+        db_driver: orm # other valid values are 'mongodb' and 'couchdb'
+        consumer_class: Acme\OAuthBundle\Entity\Consumer
+        request_token_class: Acme\OAuthBundle\Entity\RequestToken
+        access_token_class: Acme\OAuthBundle\Entity\AccessToken
+```
+
+That's all for the installation :-)
 
 ## Configuration
 In order to use this bundle, you have to configure it.
@@ -226,10 +341,9 @@ To enable it in your application, just set the `enable_xauth` configuration para
 
 ``` yaml
 # app/config/config.yml
-bazinga_o_auth:
+bazinga_oauth:
     enable_xauth:   true
 ```
-
 
 ## Extending things
 This bundle provides a set of interfaces that help you to create your own implementation

--- a/Tests/Doctrine/Provider/ConsumerProviderTest.php
+++ b/Tests/Doctrine/Provider/ConsumerProviderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Bazinga\OAuthServerBundle\Tests\Doctrine\Provider;
+
+use Bazinga\OAuthServerBundle\Doctrine\Provider\ConsumerProvider;
+use Bazinga\OAuthServerBundle\Model\Consumer;
+use Bazinga\OAuthServerBundle\Tests\TestCase;
+
+/**
+ * @author Robin van der Vleuten <robinvdvleuten@gmail.com>
+ */
+class ConsumerProviderTest extends TestCase
+{
+    const CONSUMER_CLASS = 'Bazinga\OAuthServerBundle\Model\Consumer';
+
+    /**
+     * @var ConsumerProvider
+     */
+    private $consumerProvider;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $objectManager;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $objectRepository;
+
+    public function setUp()
+    {
+        if (!interface_exists('Doctrine\Common\Persistence\ObjectManager')) {
+            $this->markTestSkipped('Doctrine Common has to be installed for this test to run.');
+        }
+
+        $this->objectRepository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+
+        $this->objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+
+        $this->objectManager->expects($this->any())
+            ->method('getRepository')
+            ->with($this->equalTo(static::CONSUMER_CLASS))
+            ->will($this->returnValue($this->objectRepository));
+
+        $this->consumerProvider = new ConsumerProvider($this->objectManager, static::CONSUMER_CLASS);
+    }
+
+    public function testGetClass()
+    {
+        $this->assertEquals(static::CONSUMER_CLASS, $this->consumerProvider->getClass());
+    }
+
+    public function testGetConsumerBy()
+    {
+        $criteria = array('foo' => 'bar');
+
+        $this->objectRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with($this->equalTo($criteria))
+            ->will($this->returnValue(array()));
+
+        $this->consumerProvider->getConsumerBy($criteria);
+    }
+
+    public function testGetConsumerByKey()
+    {
+        $consumerKey = 'foo';
+
+        $this->objectRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with($this->equalTo(array('consumerKey' => $consumerKey)))
+            ->will($this->returnValue(array()));
+
+        $this->consumerProvider->getConsumerByKey($consumerKey);
+    }
+}

--- a/Tests/Doctrine/Provider/TokenProviderTest.php
+++ b/Tests/Doctrine/Provider/TokenProviderTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Bazinga\OAuthServerBundle\Tests\Doctrine\Provider;
+
+use Bazinga\OAuthServerBundle\Doctrine\Provider\TokenProvider;
+use Bazinga\OAuthServerBundle\Model\AccessToken;
+use Bazinga\OAuthServerBundle\Model\RequestToken;
+use Bazinga\OAuthServerBundle\Model\Token;
+use Bazinga\OAuthServerBundle\Tests\TestCase;
+
+/**
+ * @author Robin van der Vleuten <robinvdvleuten@gmail.com>
+ */
+class TokenProviderTest extends TestCase
+{
+    const REQUEST_TOKEN_CLASS = 'Bazinga\OAuthServerBundle\Tests\Doctrine\Provider\DummyRequestToken';
+
+    const ACCESS_TOKEN_CLASS = 'Bazinga\OAuthServerBundle\Tests\Doctrine\Provider\DummyAccessToken';
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $objectRepository;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $objectManager;
+
+    /**
+     * @var TokenProvider
+     */
+    private $tokenProvider;
+
+    public function setUp()
+    {
+        if (!interface_exists('Doctrine\Common\Persistence\ObjectManager')) {
+            $this->markTestSkipped('Doctrine Common has to be installed for this test to run.');
+        }
+
+        $this->objectRepository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+
+        $this->objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+
+        $this->objectManager->expects($this->at(0))
+            ->method('getRepository')
+            ->with($this->equalTo(static::REQUEST_TOKEN_CLASS))
+            ->will($this->returnValue($this->objectRepository));
+
+        $this->objectManager->expects($this->at(1))
+            ->method('getRepository')
+            ->with($this->equalTo(static::ACCESS_TOKEN_CLASS))
+            ->will($this->returnValue($this->objectRepository));
+
+        $this->tokenProvider = new TokenProvider($this->objectManager, static::REQUEST_TOKEN_CLASS, static::ACCESS_TOKEN_CLASS);
+    }
+
+    public function testGetRequestTokenClass()
+    {
+        $this->assertEquals(static::REQUEST_TOKEN_CLASS, $this->tokenProvider->getRequestTokenClass());
+    }
+
+    public function testGetAccessTokenClass()
+    {
+        $this->assertEquals(static::ACCESS_TOKEN_CLASS, $this->tokenProvider->getAccessTokenClass());
+    }
+
+    public function testLoadRequestTokenBy()
+    {
+        $criteria = array('foo' => 'bar');
+
+        $this->objectRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with($this->equalTo($criteria))
+            ->will($this->returnValue(array()));
+
+        $this->tokenProvider->loadRequestTokenBy($criteria);
+    }
+
+    public function testLoadRequestTokenByToken()
+    {
+        $token = 'foo';
+
+        $this->objectRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with($this->equalTo(array('token' => $token)))
+            ->will($this->returnValue(array()));
+
+        $this->tokenProvider->loadRequestTokenByToken($token);
+    }
+
+    public function testLoadRequestTokens()
+    {
+        $this->objectRepository->expects($this->once())
+            ->method('findAll')
+            ->will($this->returnValue(array()));
+
+        $this->tokenProvider->loadRequestTokens();
+    }
+
+    public function testCreateRequestToken()
+    {
+        $consumer = $this->getMock('Bazinga\OAuthServerBundle\Model\ConsumerInterface');
+
+        $this->objectManager->expects($this->once())
+            ->method('persist')
+            ->with($this->isInstanceOf(static::REQUEST_TOKEN_CLASS));
+
+        $this->objectManager->expects($this->once())
+            ->method('flush');
+
+        $token = $this->tokenProvider->createRequestToken($consumer);
+
+        $this->assertInstanceOf(static::REQUEST_TOKEN_CLASS, $token);
+    }
+
+    public function testDeleteRequestToken()
+    {
+        $token = new DummyRequestToken();
+
+        $this->objectManager->expects($this->once())
+            ->method('remove')
+            ->with($this->equalTo($token));
+
+        $this->objectManager->expects($this->once())
+            ->method('flush');
+
+        $this->tokenProvider->deleteRequestToken($token);
+    }
+
+    public function testSetUserForRequestToken()
+    {
+        $token = new DummyRequestToken();
+        $user = $this->getMock('Bazinga\OAuthServerBundle\Model\UserInterface');
+
+        $this->objectManager->expects($this->once())
+            ->method('persist')
+            ->with($this->equalTo($token));
+
+        $this->objectManager->expects($this->once())
+            ->method('flush');
+
+        $this->tokenProvider->setUserForRequestToken($token, $user);
+
+        $this->assertEquals($user, $token->getUser());
+    }
+
+    public function testLoadAccessTokenBy()
+    {
+        $criteria = array('foo' => 'bar');
+
+        $this->objectRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with($this->equalTo($criteria))
+            ->will($this->returnValue(array()));
+
+        $this->tokenProvider->loadAccessTokenBy($criteria);
+    }
+
+    public function testLoadAccessTokenByToken()
+    {
+        $token = 'foo';
+
+        $this->objectRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with($this->equalTo(array('token' => $token)))
+            ->will($this->returnValue(array()));
+
+        $this->tokenProvider->loadAccessTokenByToken($token);
+    }
+
+    public function testLoadAccessTokens()
+    {
+        $this->objectRepository->expects($this->once())
+            ->method('findAll')
+            ->will($this->returnValue(array()));
+
+        $this->tokenProvider->loadAccessTokens();
+    }
+
+    public function testCreateAccessToken()
+    {
+        $consumer = $this->getMock('Bazinga\OAuthServerBundle\Model\ConsumerInterface');
+        $user = $this->getMock('Bazinga\OAuthServerBundle\Model\UserInterface');
+
+        $this->objectManager->expects($this->once())
+            ->method('persist')
+            ->with($this->isInstanceOf(static::ACCESS_TOKEN_CLASS));
+
+        $this->objectManager->expects($this->once())
+            ->method('flush');
+
+        $token = $this->tokenProvider->createAccessToken($consumer, $user);
+
+        $this->assertInstanceOf(static::ACCESS_TOKEN_CLASS, $token);
+    }
+
+    public function testDeleteAccessToken()
+    {
+        $token = new DummyAccessToken();
+
+        $this->objectManager->expects($this->once())
+            ->method('remove')
+            ->with($this->equalTo($token));
+
+        $this->objectManager->expects($this->once())
+            ->method('flush');
+
+        $this->tokenProvider->deleteAccessToken($token);
+    }
+
+    public function testDeleteToken()
+    {
+        $token = new DummyToken();
+
+        $this->objectManager->expects($this->once())
+            ->method('remove')
+            ->with($this->equalTo($token));
+
+        $this->objectManager->expects($this->once())
+            ->method('flush');
+
+        $this->tokenProvider->deleteToken($token);
+    }
+
+    public function testDeleteExpired()
+    {
+        $requestToken = $this->getMock(static::REQUEST_TOKEN_CLASS);
+
+        $requestToken->expects($this->once())
+            ->method('hasExpired')
+            ->will($this->returnValue(true));
+
+        $this->objectRepository->expects($this->at(0))
+            ->method('findAll')
+            ->will($this->returnValue(array($requestToken)));
+
+        $accessToken = $this->getMock(static::ACCESS_TOKEN_CLASS);
+
+        $accessToken->expects($this->once())
+            ->method('hasExpired')
+            ->will($this->returnValue(false));
+
+        $this->objectRepository->expects($this->at(1))
+            ->method('findAll')
+            ->will($this->returnValue(array($accessToken)));
+
+        $this->objectManager->expects($this->once())
+            ->method('remove')
+            ->with($this->isInstanceOf('Bazinga\OAuthServerBundle\Model\TokenInterface'));
+
+        $this->tokenProvider->deleteExpired();
+    }
+
+    public function testUpdateToken()
+    {
+        $token = new DummyToken();
+
+        $this->objectManager->expects($this->once())
+            ->method('persist')
+            ->with($this->equalTo($token));
+
+        $this->objectManager->expects($this->once())
+            ->method('flush');
+
+        $this->tokenProvider->updateToken($token);
+    }
+}
+
+class DummyToken extends Token
+{
+
+}
+
+class DummyRequestToken extends RequestToken
+{
+
+}
+
+class DummyAccessToken extends AccessToken
+{
+
+}

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/console": "~2.1",
-        "symfony/framework-bundle": "~2.1",
-        "symfony/security-bundle": "~2.1"
+        "symfony/console": "~2.3",
+        "symfony/framework-bundle": "~2.3",
+        "symfony/security-bundle": "~2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7"
+        "doctrine/doctrine-bundle": "1.3.*@dev"
     },
     "autoload": {
         "psr-4": { "Bazinga\\OAuthServerBundle\\": "" }

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "7d60ff6bff8c5decc01e9e69c355454c",
+    "hash": "0d144ee2b6324200641106c9850aca0b",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -169,17 +169,17 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/Config",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Config.git",
-                "reference": "27d0b35879ebefcfee6d218512c32ab2d6cd6a6a"
+                "reference": "d81bd01eac1514c10dcb3b11eaa9048d6b87dd1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/27d0b35879ebefcfee6d218512c32ab2d6cd6a6a",
-                "reference": "27d0b35879ebefcfee6d218512c32ab2d6cd6a6a",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/d81bd01eac1514c10dcb3b11eaa9048d6b87dd1f",
+                "reference": "d81bd01eac1514c10dcb3b11eaa9048d6b87dd1f",
                 "shasum": ""
             },
             "require": {
@@ -204,7 +204,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -213,21 +215,21 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "http://symfony.com",
-            "time": "2014-01-01 08:14:50"
+            "time": "2014-01-07 13:28:54"
         },
         {
             "name": "symfony/console",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "4c1ed2ff514bd85ee186eebb010ccbdeeab05af7"
+                "reference": "940f217cbc3c8a33e5403e7c595495c4884400fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/4c1ed2ff514bd85ee186eebb010ccbdeeab05af7",
-                "reference": "4c1ed2ff514bd85ee186eebb010ccbdeeab05af7",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/940f217cbc3c8a33e5403e7c595495c4884400fe",
+                "reference": "940f217cbc3c8a33e5403e7c595495c4884400fe",
                 "shasum": ""
             },
             "require": {
@@ -268,21 +270,21 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
-            "time": "2014-01-01 08:14:50"
+            "time": "2014-02-11 13:52:09"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/Debug",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Debug.git",
-                "reference": "74110be5ec681a83fc5bd66dd5fd29fe85fe9c1f"
+                "reference": "23b5f4fcad883679d9a6e1cbc568247fe606d8ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Debug/zipball/74110be5ec681a83fc5bd66dd5fd29fe85fe9c1f",
-                "reference": "74110be5ec681a83fc5bd66dd5fd29fe85fe9c1f",
+                "url": "https://api.github.com/repos/symfony/Debug/zipball/23b5f4fcad883679d9a6e1cbc568247fe606d8ee",
+                "reference": "23b5f4fcad883679d9a6e1cbc568247fe606d8ee",
                 "shasum": ""
             },
             "require": {
@@ -314,7 +316,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -323,21 +327,21 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "http://symfony.com",
-            "time": "2014-01-01 09:02:49"
+            "time": "2014-02-11 13:52:09"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/DependencyInjection",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/DependencyInjection.git",
-                "reference": "7e5bde3a607dde1f8ddef5180759068ad53d259c"
+                "reference": "dde921399691bdb3b32a3c2557dcb2054db7593a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/7e5bde3a607dde1f8ddef5180759068ad53d259c",
-                "reference": "7e5bde3a607dde1f8ddef5180759068ad53d259c",
+                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/dde921399691bdb3b32a3c2557dcb2054db7593a",
+                "reference": "dde921399691bdb3b32a3c2557dcb2054db7593a",
                 "shasum": ""
             },
             "require": {
@@ -371,7 +375,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -380,21 +386,21 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "http://symfony.com",
-            "time": "2014-01-01 09:02:49"
+            "time": "2014-02-11 13:52:09"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/EventDispatcher",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "e3ba42f6a70554ed05749e61b829550f6ac33601"
+                "reference": "4708b8cd41984a5ba29fe7dd40716f7f761ac501"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/e3ba42f6a70554ed05749e61b829550f6ac33601",
-                "reference": "e3ba42f6a70554ed05749e61b829550f6ac33601",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/4708b8cd41984a5ba29fe7dd40716f7f761ac501",
+                "reference": "4708b8cd41984a5ba29fe7dd40716f7f761ac501",
                 "shasum": ""
             },
             "require": {
@@ -425,7 +431,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -434,21 +442,21 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "http://symfony.com",
-            "time": "2013-12-28 08:12:03"
+            "time": "2014-02-11 13:52:09"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/Filesystem",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "b3c3b5a8108b3e5d604dc23241b4ea84a067fc78"
+                "reference": "7e65abb06d3b38f4be89266fe3fb4a759544e713"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/b3c3b5a8108b3e5d604dc23241b4ea84a067fc78",
-                "reference": "b3c3b5a8108b3e5d604dc23241b4ea84a067fc78",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/7e65abb06d3b38f4be89266fe3fb4a759544e713",
+                "reference": "7e65abb06d3b38f4be89266fe3fb4a759544e713",
                 "shasum": ""
             },
             "require": {
@@ -472,7 +480,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -481,21 +491,21 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "http://symfony.com",
-            "time": "2013-12-31 13:43:26"
+            "time": "2014-01-07 13:28:54"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Bundle/FrameworkBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/FrameworkBundle.git",
-                "reference": "39ab0c473e474bd9c69acc3ff0dced4d97b23bb2"
+                "reference": "aa3e1310b4d95570c8f813e90a89fe36bdfeb8b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/FrameworkBundle/zipball/39ab0c473e474bd9c69acc3ff0dced4d97b23bb2",
-                "reference": "39ab0c473e474bd9c69acc3ff0dced4d97b23bb2",
+                "url": "https://api.github.com/repos/symfony/FrameworkBundle/zipball/aa3e1310b4d95570c8f813e90a89fe36bdfeb8b2",
+                "reference": "aa3e1310b4d95570c8f813e90a89fe36bdfeb8b2",
                 "shasum": ""
             },
             "require": {
@@ -546,7 +556,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -555,21 +567,21 @@
             ],
             "description": "Symfony FrameworkBundle",
             "homepage": "http://symfony.com",
-            "time": "2014-01-01 08:14:50"
+            "time": "2014-02-11 13:52:09"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/HttpFoundation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/HttpFoundation.git",
-                "reference": "6c6b8a7bcd7e2cc920cd6acace563fdbf121d844"
+                "reference": "cdee7c84ba8b2a8aafa1c055f5cb4f640d81c129"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/6c6b8a7bcd7e2cc920cd6acace563fdbf121d844",
-                "reference": "6c6b8a7bcd7e2cc920cd6acace563fdbf121d844",
+                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/cdee7c84ba8b2a8aafa1c055f5cb4f640d81c129",
+                "reference": "cdee7c84ba8b2a8aafa1c055f5cb4f640d81c129",
                 "shasum": ""
             },
             "require": {
@@ -596,7 +608,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -605,21 +619,21 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "http://symfony.com",
-            "time": "2014-01-05 02:10:50"
+            "time": "2014-02-11 15:39:28"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/HttpKernel",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/HttpKernel.git",
-                "reference": "0605eedeb52c4d3a3144128d8336395a57be60d4"
+                "reference": "445d6eee0eab2a6cfab41b5dc43f1b86ec34d110"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpKernel/zipball/0605eedeb52c4d3a3144128d8336395a57be60d4",
-                "reference": "0605eedeb52c4d3a3144128d8336395a57be60d4",
+                "url": "https://api.github.com/repos/symfony/HttpKernel/zipball/445d6eee0eab2a6cfab41b5dc43f1b86ec34d110",
+                "reference": "445d6eee0eab2a6cfab41b5dc43f1b86ec34d110",
                 "shasum": ""
             },
             "require": {
@@ -667,7 +681,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -676,21 +692,21 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "http://symfony.com",
-            "time": "2014-01-05 02:12:11"
+            "time": "2014-02-12 19:27:03"
         },
         {
             "name": "symfony/routing",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/Routing",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Routing.git",
-                "reference": "4abfb500aab8be458c9e3a227ea56b190584f78a"
+                "reference": "b2fdea8b60400bb84e4931d71101ebbb3a08c1eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Routing/zipball/4abfb500aab8be458c9e3a227ea56b190584f78a",
-                "reference": "4abfb500aab8be458c9e3a227ea56b190584f78a",
+                "url": "https://api.github.com/repos/symfony/Routing/zipball/b2fdea8b60400bb84e4931d71101ebbb3a08c1eb",
+                "reference": "b2fdea8b60400bb84e4931d71101ebbb3a08c1eb",
                 "shasum": ""
             },
             "require": {
@@ -727,7 +743,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -742,21 +760,21 @@
                 "uri",
                 "url"
             ],
-            "time": "2014-01-05 02:10:50"
+            "time": "2014-02-11 13:52:09"
         },
         {
             "name": "symfony/security",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/Security",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Security.git",
-                "reference": "b1021ae160f5425986dea2b62d3f14a0bbbf448a"
+                "reference": "ae020b9dc10e6438dc4033103c16bae7d46a4dd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Security/zipball/b1021ae160f5425986dea2b62d3f14a0bbbf448a",
-                "reference": "b1021ae160f5425986dea2b62d3f14a0bbbf448a",
+                "url": "https://api.github.com/repos/symfony/Security/zipball/ae020b9dc10e6438dc4033103c16bae7d46a4dd6",
+                "reference": "ae020b9dc10e6438dc4033103c16bae7d46a4dd6",
                 "shasum": ""
             },
             "require": {
@@ -807,7 +825,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -816,21 +836,21 @@
             ],
             "description": "Symfony Security Component",
             "homepage": "http://symfony.com",
-            "time": "2014-01-01 08:14:50"
+            "time": "2014-02-11 13:52:09"
         },
         {
             "name": "symfony/security-bundle",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Bundle/SecurityBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/SecurityBundle.git",
-                "reference": "5a056066adda61cb1f74638eab963c6aca159dbc"
+                "reference": "8c4718920326e14aa28e7045fefe46678f992050"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/SecurityBundle/zipball/5a056066adda61cb1f74638eab963c6aca159dbc",
-                "reference": "5a056066adda61cb1f74638eab963c6aca159dbc",
+                "url": "https://api.github.com/repos/symfony/SecurityBundle/zipball/8c4718920326e14aa28e7045fefe46678f992050",
+                "reference": "8c4718920326e14aa28e7045fefe46678f992050",
                 "shasum": ""
             },
             "require": {
@@ -863,7 +883,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -872,21 +894,21 @@
             ],
             "description": "Symfony SecurityBundle",
             "homepage": "http://symfony.com",
-            "time": "2013-12-31 11:02:51"
+            "time": "2014-02-11 13:52:09"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/Stopwatch",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Stopwatch.git",
-                "reference": "c8e21e1380c7eef6197a8165620da8457b7c69a5"
+                "reference": "bffad325e36a3e71fba6d5dcce6e2f4b4637b91a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/c8e21e1380c7eef6197a8165620da8457b7c69a5",
-                "reference": "c8e21e1380c7eef6197a8165620da8457b7c69a5",
+                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/bffad325e36a3e71fba6d5dcce6e2f4b4637b91a",
+                "reference": "bffad325e36a3e71fba6d5dcce6e2f4b4637b91a",
                 "shasum": ""
             },
             "require": {
@@ -910,7 +932,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -919,21 +943,21 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "http://symfony.com",
-            "time": "2013-12-12 16:06:47"
+            "time": "2014-02-11 13:52:09"
         },
         {
             "name": "symfony/templating",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/Templating",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Templating.git",
-                "reference": "de4e17db80771019c4845e42e82a0bf3d5107b65"
+                "reference": "2bd48c405223b719d3e38e9f071e00bdc4a9a780"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Templating/zipball/de4e17db80771019c4845e42e82a0bf3d5107b65",
-                "reference": "de4e17db80771019c4845e42e82a0bf3d5107b65",
+                "url": "https://api.github.com/repos/symfony/Templating/zipball/2bd48c405223b719d3e38e9f071e00bdc4a9a780",
+                "reference": "2bd48c405223b719d3e38e9f071e00bdc4a9a780",
                 "shasum": ""
             },
             "require": {
@@ -963,7 +987,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -972,21 +998,21 @@
             ],
             "description": "Symfony Templating Component",
             "homepage": "http://symfony.com",
-            "time": "2014-01-01 08:14:50"
+            "time": "2014-02-11 15:39:28"
         },
         {
             "name": "symfony/translation",
-            "version": "v2.4.1",
+            "version": "v2.4.2",
             "target-dir": "Symfony/Component/Translation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Translation.git",
-                "reference": "7f76dffd7eaf2c9a3a8f47649404c71440d18c8b"
+                "reference": "b00fd07417e493e08488e87bcebeb9681fc7323b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Translation/zipball/7f76dffd7eaf2c9a3a8f47649404c71440d18c8b",
-                "reference": "7f76dffd7eaf2c9a3a8f47649404c71440d18c8b",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/b00fd07417e493e08488e87bcebeb9681fc7323b",
+                "reference": "b00fd07417e493e08488e87bcebeb9681fc7323b",
                 "shasum": ""
             },
             "require": {
@@ -1018,7 +1044,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -1027,36 +1055,100 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "http://symfony.com",
-            "time": "2013-12-31 13:43:26"
+            "time": "2014-02-03 17:15:33"
         }
     ],
     "packages-dev": [
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "1.2.15",
+            "name": "doctrine/cache",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6ba4ed2895d538a039d5d5866edc4ec0424c7852"
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "e16d7adf45664a50fa86f515b6d5e7f670130449"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6ba4ed2895d538a039d5d5866edc4ec0424c7852",
-                "reference": "6ba4ed2895d538a039d5d5866edc4ec0424c7852",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/e16d7adf45664a50fa86f515b6d5e7f670130449",
+                "reference": "e16d7adf45664a50fa86f515b6d5e7f670130449",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": ">=1.3.0@stable",
-                "phpunit/php-text-template": ">=1.2.0@stable",
-                "phpunit/php-token-stream": ">=1.1.3@stable"
+                "php": ">=5.3.2"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "3.7.*@dev"
+                "phpunit/phpunit": ">=3.7",
+                "satooshi/php-coveralls": "~0.6"
             },
-            "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.0.5"
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Cache\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com",
+                    "homepage": "http://www.instaclick.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "http://jmsyst.com",
+                    "role": "Developer of wrapped JMSSerializerBundle"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2013-10-25 19:04:14"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "b99c5c46c87126201899afe88ec490a25eedd6a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/b99c5c46c87126201899afe88ec490a25eedd6a2",
+                "reference": "b99c5c46c87126201899afe88ec490a25eedd6a2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
             },
             "type": "library",
             "extra": {
@@ -1065,366 +1157,237 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "PHP/"
-                ]
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
-            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
-            "keywords": [
-                "coverage",
-                "testing",
-                "xunit"
-            ],
-            "time": "2014-02-03 07:44:47"
-        },
-        {
-            "name": "phpunit/php-file-iterator",
-            "version": "1.3.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
-                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "File/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com",
+                    "homepage": "http://www.instaclick.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "http://jmsyst.com",
+                    "role": "Developer of wrapped JMSSerializerBundle"
                 }
             ],
-            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
             "keywords": [
-                "filesystem",
+                "array",
+                "collections",
                 "iterator"
             ],
-            "time": "2013-10-10 15:34:57"
+            "time": "2014-02-03 23:07:43"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "Text/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Simple template engine.",
-            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
-            "keywords": [
-                "template"
-            ],
-            "time": "2014-01-30 17:20:04"
-        },
-        {
-            "name": "phpunit/php-timer",
-            "version": "1.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "PHP/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "time": "2013-08-02 07:42:54"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "1.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "5220af2a7929aa35cf663d97c89ad3d50cf5fa3e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/5220af2a7929aa35cf663d97c89ad3d50cf5fa3e",
-                "reference": "5220af2a7929aa35cf663d97c89ad3d50cf5fa3e",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "PHP/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "time": "2013-09-13 04:58:23"
-        },
-        {
-            "name": "phpunit/phpunit",
-            "version": "3.7.31",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d24e9877331039582497052cc3c4d9f465b88210"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d24e9877331039582497052cc3c4d9f465b88210",
-                "reference": "d24e9877331039582497052cc3c4d9f465b88210",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpunit/php-code-coverage": "~1.2.1",
-                "phpunit/php-file-iterator": ">=1.3.1",
-                "phpunit/php-text-template": ">=1.1.1",
-                "phpunit/php-timer": ">=1.0.4",
-                "phpunit/phpunit-mock-objects": "~1.2.0",
-                "symfony/yaml": "~2.0"
-            },
-            "require-dev": {
-                "pear-pear/pear": "1.9.4"
-            },
-            "suggest": {
-                "ext-json": "*",
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "phpunit/php-invoker": ">=1.1.0,<1.2.0"
-            },
-            "bin": [
-                "composer/bin/phpunit"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.7.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "PHPUnit/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                "",
-                "../../symfony/yaml/"
-            ],
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "The PHP Unit Testing framework.",
-            "homepage": "http://www.phpunit.de/",
-            "keywords": [
-                "phpunit",
-                "testing",
-                "xunit"
-            ],
-            "time": "2014-02-03 07:46:27"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "1.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5794e3c5c5ba0fb037b11d8151add2a07fa82875",
-                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": ">=1.1.1@stable"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "PHPUnit/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "time": "2013-01-13 10:24:48"
-        },
-        {
-            "name": "symfony/yaml",
+            "name": "doctrine/common",
             "version": "v2.4.1",
-            "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
-                "reference": "4e1a237fc48145fae114b96458d799746ad89aa0"
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "ceb18cf9b0230f3ea208b6238130fd415abda0a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4e1a237fc48145fae114b96458d799746ad89aa0",
-                "reference": "4e1a237fc48145fae114b96458d799746ad89aa0",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/ceb18cf9b0230f3ea208b6238130fd415abda0a7",
+                "reference": "ceb18cf9b0230f3ea208b6238130fd415abda0a7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": ">=5.3.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev"
+                    "dev-master": "2.4.x-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
-                    "Symfony\\Component\\Yaml\\": ""
+                    "Doctrine\\Common\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com",
+                    "homepage": "http://www.instaclick.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "http://jmsyst.com",
+                    "role": "Developer of wrapped JMSSerializerBundle"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2013-09-07 10:20:34"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "fec965d330c958e175c39e61c3f6751955af32d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/fec965d330c958e175c39e61c3f6751955af32d0",
+                "reference": "fec965d330c958e175c39e61c3f6751955af32d0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "~2.4",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*",
+                "symfony/console": "~2.0"
+            },
+            "suggest": {
+                "symfony/console": "Allows use of the command line interface"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com",
+                    "homepage": "http://www.instaclick.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2014-01-01 16:43:57"
+        },
+        {
+            "name": "doctrine/doctrine-bundle",
+            "version": "dev-master",
+            "target-dir": "Doctrine/Bundle/DoctrineBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineBundle.git",
+                "reference": "326bc9422817a0c3abe4551fd3b816a066947630"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/326bc9422817a0c3abe4551fd3b816a066947630",
+                "reference": "326bc9422817a0c3abe4551fd3b816a066947630",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "~2.3",
+                "doctrine/doctrine-cache-bundle": "~1.0",
+                "jdorn/sql-formatter": "~1.1",
+                "php": ">=5.3.2",
+                "symfony/doctrine-bridge": "~2.2",
+                "symfony/framework-bundle": "~2.2"
+            },
+            "require-dev": {
+                "doctrine/orm": "~2.3",
+                "phpunit/php-code-coverage": "~1.2",
+                "phpunit/phpunit": "~3.7",
+                "phpunit/phpunit-mock-objects": "~1.2",
+                "satooshi/php-coveralls": "~0.6.1",
+                "symfony/validator": "~2.2",
+                "symfony/yaml": "~2.2",
+                "twig/twig": "~1"
+            },
+            "suggest": {
+                "doctrine/orm": "The Doctrine ORM integration is optional in the bundle.",
+                "symfony/web-profiler-bundle": "to use the data collector"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Bundle\\DoctrineBundle": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1434,25 +1397,308 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "http://www.doctrine-project.org/"
+                }
+            ],
+            "description": "Symfony DoctrineBundle",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "orm",
+                "persistence"
+            ],
+            "time": "2014-03-04 21:50:51"
+        },
+        {
+            "name": "doctrine/doctrine-cache-bundle",
+            "version": "1.0.0",
+            "target-dir": "Doctrine/Bundle/DoctrineCacheBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineCacheBundle.git",
+                "reference": "49a9d2d9a35863201e5e608d1194db28946c4552"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineCacheBundle/zipball/49a9d2d9a35863201e5e608d1194db28946c4552",
+                "reference": "49a9d2d9a35863201e5e608d1194db28946c4552",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "~1.3",
+                "doctrine/inflector": "~1.0",
+                "php": ">=5.3.2",
+                "symfony/doctrine-bridge": "~2.2",
+                "symfony/framework-bundle": "~2.2",
+                "symfony/security": "~2.2"
+            },
+            "require-dev": {
+                "instaclick/coding-standard": "~1.1",
+                "instaclick/object-calisthenics-sniffs": "dev-master",
+                "instaclick/symfony2-coding-standard": "dev-remaster",
+                "phpunit/phpunit": "~3.7",
+                "satooshi/php-coveralls": "~0.6.1",
+                "squizlabs/php_codesniffer": "dev-master",
+                "symfony/validator": "~2.2",
+                "symfony/yaml": "~2.2"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Bundle\\DoctrineCacheBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Fabio B. Silva",
+                    "email": "fabio.bat.silva@gmail.com"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@hotmail.com"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "http://www.doctrine-project.org/"
+                }
+            ],
+            "description": "Symfony2 Bundle for Doctrine Cache",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2014-03-04 19:18:55"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "54b8333d2a5682afdc690060c1cf384ba9f47f08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/54b8333d2a5682afdc690060c1cf384ba9f47f08",
+                "reference": "54b8333d2a5682afdc690060c1cf384ba9f47f08",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Inflector\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com",
+                    "homepage": "http://www.instaclick.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "http://jmsyst.com",
+                    "role": "Developer of wrapped JMSSerializerBundle"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "inflection",
+                "pluarlize",
+                "singuarlize",
+                "string"
+            ],
+            "time": "2013-01-10 21:49:15"
+        },
+        {
+            "name": "jdorn/sql-formatter",
+            "version": "v1.2.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jdorn/sql-formatter.git",
+                "reference": "64990d96e0959dff8e059dfcdc1af130728d92bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jdorn/sql-formatter/zipball/64990d96e0959dff8e059dfcdc1af130728d92bc",
+                "reference": "64990d96e0959dff8e059dfcdc1af130728d92bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "lib"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Dorn",
+                    "email": "jeremy@jeremydorn.com",
+                    "homepage": "http://jeremydorn.com/"
+                }
+            ],
+            "description": "a PHP SQL highlighting library",
+            "homepage": "https://github.com/jdorn/sql-formatter/",
+            "keywords": [
+                "highlight",
+                "sql"
+            ],
+            "time": "2014-01-12 16:20:24"
+        },
+        {
+            "name": "symfony/doctrine-bridge",
+            "version": "v2.4.2",
+            "target-dir": "Symfony/Bridge/Doctrine",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/DoctrineBridge.git",
+                "reference": "dec8ae317321c9646ff259b5adf53aae3f989f85"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/DoctrineBridge/zipball/dec8ae317321c9646ff259b5adf53aae3f989f85",
+                "reference": "dec8ae317321c9646ff259b5adf53aae3f989f85",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "~2.2",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "doctrine/data-fixtures": "1.0.*",
+                "doctrine/dbal": "~2.2",
+                "doctrine/orm": "~2.2,>=2.2.3",
+                "symfony/dependency-injection": "~2.0",
+                "symfony/expression-language": "~2.2",
+                "symfony/form": "~2.2",
+                "symfony/http-kernel": "~2.2",
+                "symfony/security": "~2.2",
+                "symfony/stopwatch": "~2.2",
+                "symfony/validator": "~2.2"
+            },
+            "suggest": {
+                "doctrine/data-fixtures": "",
+                "doctrine/dbal": "",
+                "doctrine/orm": "",
+                "symfony/form": "",
+                "symfony/validator": ""
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Bridge\\Doctrine\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "http://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Yaml Component",
+            "description": "Symfony Doctrine Bridge",
             "homepage": "http://symfony.com",
-            "time": "2013-12-28 08:12:03"
+            "time": "2014-02-11 13:52:09"
         }
     ],
     "aliases": [
 
     ],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": {
+        "doctrine/doctrine-bundle": 20
+    },
     "platform": {
         "php": ">=5.3.3"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | n |
| New Feature? | y |
| BC Breaks? | y |
| Deprecations? | n |
| Tests Pass? | y |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |

Added provider classses and model mappings for all doctrine datastores. The correct classes for Propel are going to be in a next PR, otherwise this one was going to be massive.
