### PR TITLE
Adds support for callback URIs that include query parameters

### DIFF
--- a/Service/OAuthServerService.php
+++ b/Service/OAuthServerService.php
@@ -201,7 +201,9 @@ class OAuthServerService extends OAuthAbstractServerService
             // Out Of Band
             return $authorizeString;
         } else {
-            return sprintf('%s?%s', $oauth_callback, $authorizeString);
+            $format = (strpos($oauth_callback, '?') !== false) ? '%s&%s' : '%s?%s';
+
+            return sprintf($format, $oauth_callback, $authorizeString);
         }
     }
 


### PR DESCRIPTION
Right now, if the callback URI already has a query appended, it'll return with something like index.php?parameter=value?oauth_token=...

This adds a check to use an ampersand instead of question mark if the the callback URI already has a query appended.  System's such as Joomla CMS requires a callback that supports this.