### PR TITLE
Adds .htaccess authorization header workaround for fcgi web servers

### DIFF
--- a/EventListener/OAuthRequestListener.php
+++ b/EventListener/OAuthRequestListener.php
@@ -77,6 +77,17 @@ class OAuthRequestListener
                     $authorization = $headers['Authorization'];
                 }
             }
+
+            if ($authorization === null) {
+                // Check to see if the header was added to $_SERVER by .htaccess
+                //     RewriteCond %{HTTP:Authorization} .+
+                //     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+                if ($request->server->has('REDIRECT_HTTP_AUTHORIZATION')) {
+                    $authorization = $request->server->get('REDIRECT_HTTP_AUTHORIZATION');
+                } elseif ($request->server->has('HTTP_AUTHORIZATION')) {
+                    $authorization = $request->server->get('HTTP_AUTHORIZATION');
+                }
+            }
         } else {
             $authorization = $request->headers->get('authorization');
         }


### PR DESCRIPTION
The Authorization header is not made available to PHP when PHP is ran under fcgi. apache_request_headers() is only available if PHP is ran under the Apache module and thus does not work for fcgi.  

The suggested code change adds support to using the .htaccess workaround posted in most related StackExchange posts that makes the header available via $_SERVER

```
    RewriteEngine On
    RewriteCond %{HTTP:Authorization} .+
    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
```
